### PR TITLE
Update aggregation_bricks_splitter_wrangler.py

### DIFF
--- a/aggregation_bricks_splitter_wrangler.py
+++ b/aggregation_bricks_splitter_wrangler.py
@@ -109,10 +109,12 @@ def lambda_handler(event, context):
         data_region = data.to_json(orient="records")
 
         payload = {
-            "json_data": json.loads(data_region),
-            "regionless_code": regionless_code,
-            "region_column": region_column,
-            "RuntimeVariables": {"run_id": run_id}
+            "RuntimeVariables": {
+                "json_data": json.loads(data_region),
+                "regionless_code": regionless_code,
+                "region_column": region_column,
+                "run_id": run_id
+            }
         }
 
         # Pass the data for processing (adding of the regionless region.


### PR DESCRIPTION
When The Imputation Test Updates Go Though, This Method Will Have The Standard Pass In And So This Needs To Match.