### PR TITLE
Updated Marshmallow.

### DIFF
--- a/aggregation_column_wrangler.py
+++ b/aggregation_column_wrangler.py
@@ -4,16 +4,30 @@ import os
 
 import boto3
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     additional_aggregated_column = fields.Str(required=True)
     aggregated_column = fields.Str(required=True)
     aggregation_type = fields.Str(required=True)
@@ -61,15 +75,9 @@ def lambda_handler(event, context):
         # Needs to be declared inside the lambda_handler
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/aggregation_top2_wrangler.py
+++ b/aggregation_top2_wrangler.py
@@ -4,16 +4,30 @@ import os
 
 import boto3
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     additional_aggregated_column = fields.Str(required=True)
     aggregated_column = fields.Str(required=True)
     in_file_name = fields.Str(required=True)
@@ -64,15 +78,9 @@ def lambda_handler(event, context):
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
         logger.info("Setting-up environment configs")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/combiner.py
+++ b/combiner.py
@@ -5,16 +5,30 @@ import os
 import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     checkpoint = fields.Str(required=True)
     bucket_name = fields.Str(required=True)
     run_environment = fields.Str(required=True)
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     additional_aggregated_column = fields.Str(required=True)
     aggregated_column = fields.Str(required=True)
     in_file_name = fields.Str(required=True)
@@ -49,15 +63,9 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -52,7 +52,7 @@ jsonpickle==1.2
 jsonpointer==2.0
 jsonschema==2.6.0
 markupsafe==1.1.1
-marshmallow==2.19.5
+marshmallow==3.6.0
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==7.0.0 ; python_version > '2.7'


### PR DESCRIPTION
Moving Marshmallow on from 2.19.5 to 3.6.0 because support for 2.19.5 ends on 18/08/2020.

Updates are fairly straightforward:
Add meta class so that excess variables are excluded.

Override the basic Marshmallow Error with out custom one. This moved it out of the main code block and into the Schema itself.

Removed Dumb Way I Did Factors And Just Did A Nested Schema Instead.
Plus For Ease Of Reading Separated Out Factors Parameters Assignment.