### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ venv.bak/
 # DS_Store
 .DS_Store
 */DS_Store
+
+# Docker debugging with with VSCode (LU-5481)
+.devcontainer/


### PR DESCRIPTION
When debugging a docker container with VSCode it creates a .devcontainer directory in the root of the repository to store set up and temporary files. We do not want those files to be in the github repos.
