### PR TITLE
Lu 6623 sqs removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Steps performed:
 
     - Retrieves data From S3 bucket
     - Invokes method lambda
-    - Puts the aggregated data onto the SQS queue
+    - Puts the aggregated data in an S3 bucket
     - Sends SNS message
  <hr>
  
@@ -29,7 +29,7 @@ Steps performed:
     - Sends the dataframe to the method
     - Ensures the new columns are still present and correctly typed in the returned dataframe
     - Serialises the dataframe back to json
-    - sends the data on via SQS
+    - Saves the data in an S3 bucket 
     - Notifies via SNS   
 <hr>
 
@@ -74,7 +74,7 @@ e.g. {"success": True/False, "checkpoint"/"error": 4/"Message"}
 
 #### Combiner
 
-The combiner is used to join the outputs from the 3 aggregations back onto the original data. It is assumed that the imputed(or original if it didnt need imputing) data is stored in an s3 bucket by the imputation module; and that each of the 3 aggregation processes each write their output to sqs. <br>
-The combiner merely picks up the imputation data from s3, then 3 messages from the sqs queue. It joins these all together and sends onwards. The result of which is that the next module(disclosure) has the granular input data with the addition of aggregations merged on.
+The combiner is used to join the outputs from the 3 aggregations back onto the original data. It is assumed that the imputed(or original if it didnt need imputing) data is stored in an s3 bucket by the imputation module; and that each of the 3 aggregation processes each write their output to S3. <br>
+The combiner merely picks up the imputation data and the 3 files from the other aggregation stages from s3. It joins these all together and sends onwards. The result of which is that the next module(disclosure) has the granular input data with the addition of aggregations merged on.
 
 *The exact column can be provided as a runtime variable.

--- a/combiner.py
+++ b/combiner.py
@@ -99,7 +99,6 @@ def lambda_handler(event, context):
             first_agg = json.loads(data[0])
             second_agg = json.loads(data[1])
             third_agg = json.loads(data[2])
-            logger.info("Successfully retrievied the aggragation files for combination")
 
         # Load file content.
         first_agg_df = aws_functions.read_dataframe_from_s3(first_agg["bucket"],
@@ -108,6 +107,7 @@ def lambda_handler(event, context):
                                                              second_agg["key"])
         third_agg_df = aws_functions.read_dataframe_from_s3(third_agg["bucket"],
                                                             third_agg["key"])
+        logger.info("Successfully retrievied the aggragation files for combination")
 
         to_aggregate = [aggregated_column]
         if additional_aggregated_column != "":

--- a/combiner.py
+++ b/combiner.py
@@ -1,8 +1,6 @@
-import json
 import logging
 import os
 
-import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
 from marshmallow import EXCLUDE, Schema, fields

--- a/combiner.py
+++ b/combiner.py
@@ -29,8 +29,8 @@ class RuntimeSchema(Schema):
 
     additional_aggregated_column = fields.Str(required=True)
     aggregated_column = fields.Str(required=True)
-    in_file_name = fields.Str(required=True)
     aggregation_files = fields.Dict(required=True)
+    in_file_name = fields.Str(required=True)
     out_file_name = fields.Str(required=True)
     sns_topic_arn = fields.Str(required=True)
 
@@ -73,8 +73,8 @@ def lambda_handler(event, context):
         # Runtime Variables
         additional_aggregated_column = runtime_variables["additional_aggregated_column"]
         aggregated_column = runtime_variables["aggregated_column"]
-        in_file_name = runtime_variables["in_file_name"]
         aggregation_files = runtime_variables["aggregation_files"]
+        in_file_name = runtime_variables["in_file_name"]
         out_file_name = runtime_variables["out_file_name"]
         sns_topic_arn = runtime_variables["sns_topic_arn"]
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -23,11 +23,11 @@ combiner_runtime_variables = {
             "in_file_name": "test_wrangler_agg_input",
             "out_file_name": "test_wrangler_combiner_output.json",
             "sns_topic_arn": "fake_sns_arn",
-            "aggregation_files": [
-                '{"bucket": "test_bucket", "key": "test_wrangler_cell_prepared_output"}',
-                '{"bucket": "test_bucket", "key": "test_wrangler_ent_prepared_output"}',
-                '{"bucket": "test_bucket", "key": "test_wrangler_top2_prepared_output"}'
-            ]
+            "aggregation_files": {
+                "ent_ref_agg": "test_wrangler_cell_prepared_output",
+                "cell_agg": "test_wrangler_ent_prepared_output",
+                "top2_agg": "test_wrangler_top2_prepared_output"
+            }
         }
 }
 
@@ -49,7 +49,6 @@ method_cell_runtime_variables = {
         "aggregation_type": "sum"
     }
 }
-
 
 method_ent_runtime_variables = {
     "RuntimeVariables": {

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -191,7 +191,7 @@ def test_client_error(which_lambda, which_runtime_variables,
 
     bucket_name = which_environment_variables["bucket_name"]
     client = test_generic_library.create_bucket(bucket_name)
-    file_list = ["test_wrangler_agg_input.json"]
+    file_list = ["test_wrangler_agg_input.json", "test_wrangler_splitter_input.json"]
 
     test_generic_library.upload_files(client, bucket_name, file_list)
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -419,7 +419,8 @@ def test_calculate_row_type():
 @mock_s3
 @mock.patch('combiner.aws_functions.save_to_s3',
             side_effect=test_generic_library.replacement_save_to_s3)
-def test_combiner_success(mock_s3_put):
+@mock.patch('combiner.aws_functions.send_sns_message')
+def test_combiner_success(mock_sns, mock_s3_put):
     """
     Runs the wrangler function.
     :param mock_s3_put: Replacement Function
@@ -445,13 +446,9 @@ def test_combiner_success(mock_s3_put):
     with mock.patch.dict(lambda_combiner_function.os.environ,
                          generic_environment_variables):
 
-        with mock.patch("combiner.boto3.client") as mock_client:
-            mock_client_object = mock.Mock()
-            mock_client.return_value = mock_client_object
-
-            output = lambda_combiner_function.lambda_handler(
-                combiner_runtime_variables, test_generic_library.context_object
-            )
+        output = lambda_combiner_function.lambda_handler(
+            combiner_runtime_variables, test_generic_library.context_object
+        )
 
     with open("tests/fixtures/" +
               combiner_runtime_variables["RuntimeVariables"]["out_file_name"],
@@ -662,8 +659,8 @@ def test_wrangler_success_passed(which_lambda, which_environment_variables,
 
     with mock.patch.dict(which_lambda.os.environ,
                          which_environment_variables):
-        with mock.patch(lambda_name + '.aws_functions.save_data',
-                        side_effect=test_generic_library.replacement_save_data):
+        with mock.patch(lambda_name + '.aws_functions.save_to_s3',
+                        side_effect=test_generic_library.replacement_save_to_s3):
             with mock.patch(lambda_name + ".boto3.client") as mock_client:
                 mock_client_object = mock.Mock()
                 mock_client.return_value = mock_client_object
@@ -752,8 +749,8 @@ def test_wrangler_success_returned(which_lambda, which_environment_variables,
 
     with mock.patch.dict(which_lambda.os.environ,
                          which_environment_variables):
-        with mock.patch(lambda_name + '.aws_functions.save_data',
-                        side_effect=test_generic_library.replacement_save_data):
+        with mock.patch(lambda_name + '.aws_functions.save_to_s3',
+                        side_effect=test_generic_library.replacement_save_to_s3):
             with mock.patch(lambda_name + ".boto3.client") as mock_client:
                 mock_client_object = mock.Mock()
                 mock_client.return_value = mock_client_object

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -21,11 +21,13 @@ combiner_runtime_variables = {
             "additional_aggregated_column": "strata",
             "aggregated_column": "region",
             "in_file_name": "test_wrangler_agg_input",
-            "location": "",
             "out_file_name": "test_wrangler_combiner_output.json",
-            "outgoing_message_group_id": "test_id",
-            "queue_url": "Earl",
-            "sns_topic_arn": "fake_sns_arn"
+            "sns_topic_arn": "fake_sns_arn",
+            "aggregation_files": [
+                '{"bucket": "test_bucket", "key": "test_wrangler_cell_prepared_output"}',
+                '{"bucket": "test_bucket", "key": "test_wrangler_ent_prepared_output"}',
+                '{"bucket": "test_bucket", "key": "test_wrangler_top2_prepared_output"}'
+            ]
         }
 }
 
@@ -90,11 +92,8 @@ pre_wrangler_runtime_variables = {
         {
             "run_id": "bob",
             "in_file_name": "test_wrangler_splitter_input",
-            "location": "",
             "out_file_name_bricks": "test_wrangler_splitter_bricks_output.json",
             "out_file_name_region": "test_wrangler_splitter_region_output.json",
-            "outgoing_message_group_id": "test_id",
-            "queue_url": "Earl",
             "sns_topic_arn": "fake_sns_arn",
             "total_columns":  ["opening_stock_commons",
                                "opening_stock_facings",
@@ -132,10 +131,7 @@ wrangler_cell_runtime_variables = {
             "aggregation_type": "sum",
             "cell_total_column": "cell_total",
             "in_file_name": "test_wrangler_agg_input",
-            "location": "",
             "out_file_name": "test_wrangler_cell_output.json",
-            "outgoing_message_group_id": "test_id",
-            "queue_url": "Earl",
             "sns_topic_arn": "fake_sns_arn",
             "total_columns": ["Q608_total"]
         }
@@ -150,10 +146,7 @@ wrangler_ent_runtime_variables = {
         "aggregated_column": "region",
         "cell_total_column": "ent_ref_count",
         "aggregation_type": "nunique",
-        "location": "",
         "out_file_name": "test_wrangler_ent_output.json",
-        "outgoing_message_group_id": "test_id",
-        "queue_url": "Earl",
         "sns_topic_arn": "fake_sns_arn"
     }
 }
@@ -165,35 +158,12 @@ wrangler_top2_runtime_variables = {
             "additional_aggregated_column": "strata",
             "aggregated_column": "region",
             "in_file_name": "test_wrangler_agg_input",
-            "location": "",
             "out_file_name": "test_wrangler_top2_output.json",
-            "outgoing_message_group_id": "test_id",
-            "queue_url": "Earl",
             "sns_topic_arn": "fake_sns_arn",
             "top1_column": "largest_contributor",
             "top2_column": "second_largest_contributor",
             "total_columns": ["Q608_total"]
         }
-}
-
-fake_return = {
-    "Messages": [
-        {
-            "ReceiptHandle": "",
-            "Body":
-                '{"bucket": "test_bucket", "key": "test_wrangler_cell_prepared_output"}'
-        },
-        {
-            "ReceiptHandle": "",
-            "Body":
-                '{"bucket": "test_bucket", "key": "test_wrangler_ent_prepared_output"}'
-        },
-        {
-            "ReceiptHandle": "",
-            "Body":
-                '{"bucket": "test_bucket", "key": "test_wrangler_top2_prepared_output"}'
-        }
-    ]
 }
 
 ##########################################################################################
@@ -267,8 +237,6 @@ def test_general_error(which_lambda, which_runtime_variables,
 
 
 @mock_s3
-@mock.patch('aggregation_bricks_splitter_wrangler.aws_functions.get_dataframe',
-            side_effect=test_generic_library.replacement_get_dataframe)
 @pytest.mark.parametrize(
     "which_lambda,which_runtime_variables,which_environment_variables,file_list," +
     "lambda_name,expected_message",
@@ -283,7 +251,7 @@ def test_general_error(which_lambda, which_runtime_variables,
          generic_environment_variables, ["test_wrangler_splitter_input.json"],
          "aggregation_bricks_splitter_wrangler", "IncompleteReadError"),
     ])
-def test_incomplete_read_error(mock_get_s3, which_lambda, which_runtime_variables,
+def test_incomplete_read_error(which_lambda, which_runtime_variables,
                                which_environment_variables, file_list, lambda_name,
                                expected_message):
 
@@ -325,8 +293,6 @@ def test_key_error(which_lambda, which_environment_variables,
 
 
 @mock_s3
-@mock.patch('aggregation_column_wrangler.aws_functions.get_dataframe',
-            side_effect=test_generic_library.replacement_get_dataframe)
 @pytest.mark.parametrize(
     "which_lambda,which_runtime_variables,which_environment_variables," +
     "file_list,lambda_name",
@@ -341,7 +307,7 @@ def test_key_error(which_lambda, which_environment_variables,
          generic_environment_variables, ["test_wrangler_splitter_input.json"],
          "aggregation_bricks_splitter_wrangler")
     ])
-def test_method_error(mock_s3_get, which_lambda, which_runtime_variables,
+def test_method_error(which_lambda, which_runtime_variables,
                       which_environment_variables, file_list, lambda_name):
     test_generic_library.wrangler_method_error(which_lambda,
                                                which_runtime_variables,
@@ -455,8 +421,8 @@ def test_calculate_row_type():
 
 
 @mock_s3
-@mock.patch('combiner.aws_functions.save_data',
-            side_effect=test_generic_library.replacement_save_data)
+@mock.patch('combiner.aws_functions.save_to_s3',
+            side_effect=test_generic_library.replacement_save_to_s3)
 def test_combiner_success(mock_s3_put):
     """
     Runs the wrangler function.
@@ -482,16 +448,14 @@ def test_combiner_success(mock_s3_put):
 
     with mock.patch.dict(lambda_combiner_function.os.environ,
                          generic_environment_variables):
-        with mock.patch('combiner.aws_functions.get_sqs_messages') as mock_message:
-            mock_message.return_value = fake_return
 
-            with mock.patch("combiner.boto3.client") as mock_client:
-                mock_client_object = mock.Mock()
-                mock_client.return_value = mock_client_object
+        with mock.patch("combiner.boto3.client") as mock_client:
+            mock_client_object = mock.Mock()
+            mock_client.return_value = mock_client_object
 
-                output = lambda_combiner_function.lambda_handler(
-                    combiner_runtime_variables, test_generic_library.context_object
-                )
+            output = lambda_combiner_function.lambda_handler(
+                combiner_runtime_variables, test_generic_library.context_object
+            )
 
     with open("tests/fixtures/" +
               combiner_runtime_variables["RuntimeVariables"]["out_file_name"],
@@ -566,14 +530,11 @@ def test_method_success(which_lambda, which_runtime_variables, input_data, prepa
 
 
 @mock_s3
-@mock.patch('aggregation_bricks_splitter_wrangler.aws_functions.get_dataframe',
-            side_effect=test_generic_library.replacement_get_dataframe)
 @mock.patch('aggregation_bricks_splitter_wrangler.aws_functions.save_to_s3',
             side_effect=test_generic_library.replacement_save_to_s3)
-def test_splitter_wrangler_success(mock_s3_get, mock_s3_put):
+def test_splitter_wrangler_success(mock_s3_put):
     """
     Runs the wrangler function.
-    :param mock_s3_get - Replacement Function For The Data Retrieval AWS Functionality.
     :param mock_s3_put - Replacement Function For The Data Saving AWS Functionality.
     :return Test Pass/Fail
     """

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -184,9 +184,6 @@ wrangler_top2_runtime_variables = {
          "ClientError", test_generic_library.wrangler_assert),
         (lambda_pre_wrangler_function, pre_wrangler_runtime_variables,
          generic_environment_variables, None,
-         "ClientError", test_generic_library.wrangler_assert),
-        (lambda_combiner_function, combiner_runtime_variables,
-         generic_environment_variables, None,
          "ClientError", test_generic_library.wrangler_assert)
     ])
 def test_client_error(which_lambda, which_runtime_variables,


### PR DESCRIPTION
Changes:
* Removed SQS
* Replaced save/get/read functions with appropriate alternatives
* Introduced an `aggregation_files` variable instead of relying on SQS messages for file names
* Replaced `first_agg`, `second_agg`, `third_agg` and their `..._df` counterparts with meanigfull names
* Updated tests and documentation to match.