### PR TITLE
Df spp216 bpm notifications

### DIFF
--- a/aggregation_bricks_splitter_wrangler.py
+++ b/aggregation_bricks_splitter_wrangler.py
@@ -151,7 +151,8 @@ def lambda_handler(event, context):
                 "data": json.loads(data_region),
                 "regionless_code": regionless_code,
                 "region_column": region_column,
-                "run_id": run_id
+                "run_id": run_id,
+                "bpm_queue_url": bpm_queue_url
             }
         }
 

--- a/aggregation_top2_method.py
+++ b/aggregation_top2_method.py
@@ -20,6 +20,7 @@ class RuntimeSchema(Schema):
     aggregated_column = fields.Str(required=True)
     top1_column = fields.Str(required=True)
     top2_column = fields.Str(required=True)
+    bpm_queue_url = fields.Str(required=True)
 
 
 def lambda_handler(event, context):
@@ -43,6 +44,7 @@ def lambda_handler(event, context):
     logger = general_functions.get_logger()
     error_message = ""
     run_id = 0
+    bpm_queue_url = None
     logger.info("Starting " + current_module)
 
     try:
@@ -55,6 +57,7 @@ def lambda_handler(event, context):
         logger.info("Validated parameters.")
 
         # Runtime Variables
+        bpm_queue_url = runtime_variables["bpm_queue_url"]
         data = json.loads(runtime_variables["data"])
         total_columns = runtime_variables["total_columns"]
         additional_aggregated_column = runtime_variables["additional_aggregated_column"]
@@ -88,8 +91,11 @@ def lambda_handler(event, context):
         response_json = response.to_json(orient="records")
         final_output = {"data": response_json}
     except Exception as e:
-        error_message = general_functions.handle_exception(e, current_module,
-                                                           run_id, context)
+        error_message = general_functions.handle_exception(e,
+                                                           current_module,
+                                                           run_id,
+                                                           context=context,
+                                                           bpm_queue_url=bpm_queue_url)
     finally:
         if (len(error_message)) > 0:
             logger.error(error_message)

--- a/aggregation_top2_wrangler.py
+++ b/aggregation_top2_wrangler.py
@@ -125,7 +125,8 @@ def lambda_handler(event, context):
                 "aggregated_column": aggregated_column,
                 "top1_column": top1_column,
                 "top2_column": top2_column,
-                "run_id": run_id
+                "run_id": run_id,
+                "bpm_queue_url": bpm_queue_url
             }
         }
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,3 +107,4 @@ xmltodict==0.12.0
 yamllint==1.20.0
 zipp==0.5.1
 git+https://github.com/ONSdigital/es-functions.git
+#force build

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,4 +107,3 @@ xmltodict==0.12.0
 yamllint==1.20.0
 zipp==0.5.1
 git+https://github.com/ONSdigital/es-functions.git
-#force build

--- a/tests/fixtures/test_wrangler_to_method_runtime.json
+++ b/tests/fixtures/test_wrangler_to_method_runtime.json
@@ -1,6 +1,7 @@
 {
     "additional_aggregated_column": "strata",
     "aggregated_column": "region",
+    "bpm_queue_url": "fake_queue_url",
     "data": null,
     "run_id": "bob",
     "top1_column": "largest_contributor",

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -219,24 +219,29 @@ def test_client_error(mock_bpm_status, which_lambda, which_runtime_variables,
         (lambda_wrangler_col_function, wrangler_cell_runtime_variables,
          generic_environment_variables, "aggregation_column_wrangler.EnvironmentSchema",
          "Exception", test_generic_library.wrangler_assert),
+
         (lambda_wrangler_top2_function, wrangler_top2_runtime_variables,
          generic_environment_variables, "aggregation_top2_wrangler.EnvironmentSchema",
          "Exception", test_generic_library.wrangler_assert),
+
         (lambda_pre_wrangler_function, pre_wrangler_runtime_variables,
          generic_environment_variables,
          "aggregation_bricks_splitter_wrangler.EnvironmentSchema",
          "Exception", test_generic_library.wrangler_assert),
+
         (lambda_combiner_function, combiner_runtime_variables,
          generic_environment_variables, "combiner.EnvironmentSchema",
          "Exception", test_generic_library.wrangler_assert),
+
         (lambda_method_col_function, method_cell_runtime_variables,
          False, "aggregation_column_method.RuntimeSchema",
          "Exception", test_generic_library.method_assert),
+
         (lambda_method_top2_function, method_top2_runtime_variables,
          False, "aggregation_top2_method.RuntimeSchema",
          "Exception", test_generic_library.method_assert)
     ])
-def test_general_error(which_lambda, which_runtime_variables,
+def test_general_error(mock_bpm_status, which_lambda, which_runtime_variables,
                        which_environment_variables, mockable_function,
                        expected_message, assertion):
     test_generic_library.general_error(which_lambda, which_runtime_variables,
@@ -288,6 +293,7 @@ def test_incomplete_read_error(which_lambda, which_runtime_variables,
         (lambda_method_top2_function, False,
          "KeyError", test_generic_library.method_assert, method_top2_runtime_variables)
     ])
+@mock.patch('aggregation_top2_wrangler.aws_functions.send_bpm_status')
 def test_key_error(which_lambda, which_environment_variables,
                    expected_message, assertion, which_runtime_variables):
     if not which_runtime_variables:

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -23,10 +23,12 @@ combiner_runtime_variables = {
             "in_file_name": "test_wrangler_agg_input",
             "out_file_name": "test_wrangler_combiner_output.json",
             "sns_topic_arn": "fake_sns_arn",
+            "bpm_queue_url": "fake_queue_url",
+            "total_steps": "6",
             "aggregation_files": {
                 "ent_ref_agg": "test_wrangler_cell_prepared_output",
                 "cell_agg": "test_wrangler_ent_prepared_output",
-                "top2_agg": "test_wrangler_top2_prepared_output"
+                "top2_agg": "test_wrangler_top2_prepared_output",
             }
         }
 }
@@ -69,7 +71,8 @@ method_top2_runtime_variables = {
         "additional_aggregated_column": "strata",
         "aggregated_column": "region",
         "top1_column": "largest_contributor",
-        "top2_column": "second_largest_contributor"
+        "top2_column": "second_largest_contributor",
+        "bpm_queue_url": "fake_queue_url"
     }
 }
 
@@ -81,7 +84,8 @@ method_top2_multi_runtime_variables = {
         "additional_aggregated_column": "strata",
         "aggregated_column": "region",
         "top1_column": "largest_contributor",
-        "top2_column": "second_largest_contributor"
+        "top2_column": "second_largest_contributor",
+        "bpm_queue_url": "fake_queue_url"
     }
 }
 
@@ -93,6 +97,8 @@ pre_wrangler_runtime_variables = {
             "out_file_name_bricks": "test_wrangler_splitter_bricks_output.json",
             "out_file_name_region": "test_wrangler_splitter_region_output.json",
             "sns_topic_arn": "fake_sns_arn",
+            "bpm_queue_url": "fake_queue_url",
+            "total_steps": "6",
             "total_columns":  ["opening_stock_commons",
                                "opening_stock_facings",
                                "opening_stock_engineering",
@@ -160,7 +166,9 @@ wrangler_top2_runtime_variables = {
             "sns_topic_arn": "fake_sns_arn",
             "top1_column": "largest_contributor",
             "top2_column": "second_largest_contributor",
-            "total_columns": ["Q608_total"]
+            "total_columns": ["Q608_total"],
+            "bpm_queue_url": "fake_queue_url",
+            "total_steps": "6"
         }
 }
 
@@ -184,7 +192,10 @@ wrangler_top2_runtime_variables = {
          generic_environment_variables, None,
          "ClientError", test_generic_library.wrangler_assert)
     ])
-def test_client_error(which_lambda, which_runtime_variables,
+@mock.patch('aggregation_bricks_splitter_wrangler.aws_functions.send_bpm_status')
+@mock.patch('aggregation_top2_wrangler.aws_functions.send_bpm_status')
+@mock.patch('combiner.aws_functions.send_bpm_status')
+def test_client_error(mock_bpm_status, which_lambda, which_runtime_variables,
                       which_environment_variables, which_data,
                       expected_message, assertion):
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -433,11 +433,14 @@ def test_calculate_row_type():
 @mock.patch('combiner.aws_functions.save_to_s3',
             side_effect=test_generic_library.replacement_save_to_s3)
 @mock.patch('combiner.aws_functions.send_sns_message')
-def test_combiner_success(mock_sns, mock_s3_put):
+@mock.patch('combiner.aws_functions.send_bpm_status')
+def test_combiner_success(mock_bpm_status, mock_sns, mock_s3_put):
     """
     Runs the wrangler function.
     :param mock_s3_put: Replacement Function
                         For The Data Saving AWS Functionality. - Mock.
+    :param mock_sns: Replacement function mocking SNS sends.
+    :param mock_bpm_status: Replacement function mocking bpm status calls.
     :return Test Pass/Fail
     """
     bucket_name = generic_environment_variables["bucket_name"]

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -137,7 +137,9 @@ wrangler_cell_runtime_variables = {
             "in_file_name": "test_wrangler_agg_input",
             "out_file_name": "test_wrangler_cell_output.json",
             "sns_topic_arn": "fake_sns_arn",
-            "total_columns": ["Q608_total"]
+            "total_columns": ["Q608_total"],
+            "bpm_queue_url": "fake_queue_url",
+            "total_steps": "6"
         }
 }
 
@@ -185,16 +187,16 @@ wrangler_top2_runtime_variables = {
         (lambda_wrangler_col_function, wrangler_cell_runtime_variables,
          generic_environment_variables, None,
          "ClientError", test_generic_library.wrangler_assert),
+
         (lambda_wrangler_top2_function, wrangler_top2_runtime_variables,
          generic_environment_variables, None,
          "ClientError", test_generic_library.wrangler_assert),
+
         (lambda_pre_wrangler_function, pre_wrangler_runtime_variables,
          generic_environment_variables, None,
          "ClientError", test_generic_library.wrangler_assert)
     ])
-@mock.patch('aggregation_bricks_splitter_wrangler.aws_functions.send_bpm_status')
 @mock.patch('aggregation_top2_wrangler.aws_functions.send_bpm_status')
-@mock.patch('combiner.aws_functions.send_bpm_status')
 def test_client_error(mock_bpm_status, which_lambda, which_runtime_variables,
                       which_environment_variables, which_data,
                       expected_message, assertion):

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -219,29 +219,24 @@ def test_client_error(mock_bpm_status, which_lambda, which_runtime_variables,
         (lambda_wrangler_col_function, wrangler_cell_runtime_variables,
          generic_environment_variables, "aggregation_column_wrangler.EnvironmentSchema",
          "Exception", test_generic_library.wrangler_assert),
-
         (lambda_wrangler_top2_function, wrangler_top2_runtime_variables,
          generic_environment_variables, "aggregation_top2_wrangler.EnvironmentSchema",
          "Exception", test_generic_library.wrangler_assert),
-
         (lambda_pre_wrangler_function, pre_wrangler_runtime_variables,
          generic_environment_variables,
          "aggregation_bricks_splitter_wrangler.EnvironmentSchema",
          "Exception", test_generic_library.wrangler_assert),
-
         (lambda_combiner_function, combiner_runtime_variables,
          generic_environment_variables, "combiner.EnvironmentSchema",
          "Exception", test_generic_library.wrangler_assert),
-
         (lambda_method_col_function, method_cell_runtime_variables,
          False, "aggregation_column_method.RuntimeSchema",
          "Exception", test_generic_library.method_assert),
-
         (lambda_method_top2_function, method_top2_runtime_variables,
          False, "aggregation_top2_method.RuntimeSchema",
          "Exception", test_generic_library.method_assert)
     ])
-def test_general_error(mock_bpm_status, which_lambda, which_runtime_variables,
+def test_general_error(which_lambda, which_runtime_variables,
                        which_environment_variables, mockable_function,
                        expected_message, assertion):
     test_generic_library.general_error(which_lambda, which_runtime_variables,
@@ -294,7 +289,7 @@ def test_incomplete_read_error(which_lambda, which_runtime_variables,
          "KeyError", test_generic_library.method_assert, method_top2_runtime_variables)
     ])
 @mock.patch('aggregation_top2_wrangler.aws_functions.send_bpm_status')
-def test_key_error(which_lambda, which_environment_variables,
+def test_key_error(mock_bpm_status, which_lambda, which_environment_variables,
                    expected_message, assertion, which_runtime_variables):
     if not which_runtime_variables:
         test_generic_library.key_error(which_lambda, which_environment_variables,


### PR DESCRIPTION
Splitter: 
- Made appropriate changes to defaults, marshmallow, runtime vars, payload.
- Added non-stepped notification to BPM of prerequisite task start and finish.
- Modified error config on lambda_handler to tie in with above.

Top2 Wrangler: 
- Made appropriate changes to defaults, marshmallow, runtime vars, payload.
- Added notification to BPM of aggregation start.
- Modified error config on lambda_handler to tie in with above.

Top2 Method: 
- Made appropriate changes to defaults, marshmallow, runtime vars.
- Modified error config on lambda_handler to tie in with above.

Combiner: 
- Made appropriate changes to defaults, marshmallow, runtime vars.
- Added notification to BPM of aggregation end.
- Modified error config on lambda_handler to tie in with above.

Tests:
- Added bpm_queue_url to test runtime vars.
- Patched out call to bpm queue in appropriate tests with mock.
- Corrected param docs for test_combiner_success.


